### PR TITLE
CommonFunctions.ps1 - change the behavior with an Archive option in 7zip

### DIFF
--- a/N2WSbackup.ps1
+++ b/N2WSbackup.ps1
@@ -396,7 +396,7 @@ Pop-Location
 
         $id = $return | ConvertFrom-Json
 
-#N2WS 2.5 return typo messeage!! [Cound not find policy] , thus do not match 'Could not find policy' orz
+#N2WS 2.5 return typo message!! [Cound not find policy] , thus do not match 'Could not find policy' orz
 
         IF (($id.Message -match 'not find policy') -or ($id."backup-id" -eq -1)) {
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 A set of useful utility scripts written in Powershell for Microsoft Windows Platform.
 
  - [File Maintenance](#filemaintenanceps1)
- - [Windows Service Control](#changeservicestatusps1--stopserviceps1--startserviceps1obsolute)
+ - [Windows Service Control](#changeservicestatusps1)
  - [Internet Information Server Control](#changeiisstateps1)
  - [UNC Path Mount](#mountdriveps1--unmountdriveps1)
  - [Oracle Database](#oracledb2backupmodeps1--oracledb2normalmodeps1--oraclearchivelogdeleteps1--oracleexportps1)
  - [arcserveUDP](#arcserveudpbackupps1)
+ - [Check Flag](#checkflagps1)
+ - [N2WSbackup](#n2wsbackupps1)
 
 ## Functions Detail
 
@@ -19,7 +21,7 @@ You can select files and folders with various creiteria including file size , nu
 At once manage only one folder. With Wrapper.ps1 you can manage multiple folders.
 
 
-### ChangeServiceStatus.ps1 / (StopService.ps1 / StartService.ps1)...obsolute
+### ChangeServiceStatus.ps1
 
 Start and stop Windows service.
 If you need script files StopService.ps1 and StartService.ps1 , change comment line at the parameter section.
@@ -49,6 +51,11 @@ Execute backup software [arcserveUDP](https://www.arcserve.com/data-protection-s
 ### CheckFlag.ps1
 
 Check a Flag File and if the flag file exist(or dose not exist) , delete the flag file(or make a flag file)
+
+### N2WSbackup.ps1
+
+Start backup job and get backup result of [N2WS](https://n2ws.com/) backup appliance for AWS.
+
 
 ### Wrapper.ps1
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Summary
 
-A set of useful utility scripts written in Powershell for Microsoft Windows Platform.
+A set of useful utility scripts written in PowerShell for Microsoft Windows Platform.
 
  - [File Maintenance](#filemaintenanceps1)
  - [Windows Service Control](#changeservicestatusps1)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A set of useful utility scripts written in PowerShell for Microsoft Windows Plat
  - [Oracle Database](#oracledb2backupmodeps1--oracledb2normalmodeps1--oraclearchivelogdeleteps1--oracleexportps1)
  - [arcserveUDP](#arcserveudpbackupps1)
  - [Check Flag](#checkflagps1)
- - [N2WSbackup](#n2wsbackupps1)
+ - [N2WS Backup](#n2wsbackupps1)
 
 ## Functions Detail
 


### PR DESCRIPTION
Hello,
I'm not sure if I correctly understand your approach process between the Compress and Archive option in FileMaintenance.ps1, but I consider changing the behavior for the 7zip Archive option, more described on https://www.dotnetperls.com/7-zip-examples.
Archive parameter changed from "u" to "a": Add files to archive which causes a better optimization when a new archive with timestamp was created.

```
        '^(Archive|ArchiveAndAddTimeStamp)$' {
#           $ActionTo = $ActionTo -replace "\[" , "````["
#            Compress-Archive -LiteralPath $ActionFrom -DestinationPath $ActionTo -Update > $NULL  -ErrorAction Stop
            Compress-Archive -LiteralPath $ActionFrom -DestinationPath $ActionTo -Force > $NULL  -ErrorAction Stop
            }                  

        '^((7z|7zZip)(Archive|Compress)($|AndAddTimeStamp))$' {

            Push-Location -LiteralPath $7zFolder

            IF ($ActionType -match '7zZip') {
                
                $7zType = 'zip'
                
                } else {
                $7zType = '7z'
                }

            Switch -Regex ($ActionType){
            
                'Compress' {
#                    [String]$errorDetail = .\7z.exe a $ActionTo $ActionFrom -t"$7zType"  2>&1
                    [String]$errorDetail = .\7z.exe u $ActionTo $ActionFrom -t"$7zType"  2>&1
                    Break
                    }

                'Archive' {
#                    [String]$errorDetail = .\7z.exe u $ActionTo $ActionFrom -t"$7zType"  2>&1
                    [String]$errorDetail = .\7z.exe a $ActionTo $ActionFrom -t"$7zType"  2>&1 
                    Break
                    }
            
                Default {
                    Pop-Location 
                    Throw "Internal error in 7-Zip Switch section with Action Type"
                    }            
                }
```
