### PR TITLE
CommonFunctions.ps1 -mmt switch correction

### DIFF
--- a/CommonFunctions.ps1
+++ b/CommonFunctions.ps1
@@ -300,7 +300,9 @@ process {
 
         '^(Archive|ArchiveAndAddTimeStamp)$' {
 #           $ActionTo = $ActionTo -replace "\[" , "````["
-            Compress-Archive -LiteralPath $ActionFrom -DestinationPath $ActionTo -Update > $NULL  -ErrorAction Stop
+#            Compress-Archive -LiteralPath $ActionFrom -DestinationPath $ActionTo -Update > $NULL  -ErrorAction Stop
+            Compress-Archive -LiteralPath $ActionFrom -DestinationPath $ActionTo -Force > $NULL  -ErrorAction Stop
+
             }                  
 
         '^((7z|7zZip)(Archive|Compress)($|AndAddTimeStamp))$' {
@@ -318,12 +320,14 @@ process {
             Switch -Regex ($ActionType){
             
                 'Compress' {
-                    [String]$errorDetail = .\7z.exe a $ActionTo $ActionFrom -t"$7zType" 2>&1
+#                    [String]$errorDetail = .\7z.exe a $ActionTo $ActionFrom -t"$7zType"  2>&1
+                    [String]$errorDetail = .\7z.exe u -ms on $ActionTo $ActionFrom -t"$7zType"  2>&1
                     Break
                     }
 
                 'Archive' {
-                    [String]$errorDetail = .\7z.exe u $ActionTo $ActionFrom -t"$7zType" 2>&1
+#                    [String]$errorDetail = .\7z.exe u $ActionTo $ActionFrom -t"$7zType"  2>&1
+                    [String]$errorDetail = .\7z.exe a -ms on $ActionTo $ActionFrom -t"$7zType"  2>&1 
                     Break
                     }
             

--- a/CommonFunctions.ps1
+++ b/CommonFunctions.ps1
@@ -321,13 +321,13 @@ process {
             
                 'Compress' {
 #                    [String]$errorDetail = .\7z.exe a $ActionTo $ActionFrom -t"$7zType"  2>&1
-                    [String]$errorDetail = .\7z.exe u -ms on $ActionTo $ActionFrom -t"$7zType"  2>&1
+                    [String]$errorDetail = .\7z.exe u -mmt on $ActionTo $ActionFrom -t"$7zType"  2>&1
                     Break
                     }
 
                 'Archive' {
 #                    [String]$errorDetail = .\7z.exe u $ActionTo $ActionFrom -t"$7zType"  2>&1
-                    [String]$errorDetail = .\7z.exe a -ms on $ActionTo $ActionFrom -t"$7zType"  2>&1 
+                    [String]$errorDetail = .\7z.exe a -mmt on $ActionTo $ActionFrom -t"$7zType"  2>&1 
                     Break
                     }
             

--- a/N2WSbackup.ps1
+++ b/N2WSbackup.ps1
@@ -396,7 +396,7 @@ Pop-Location
 
         $id = $return | ConvertFrom-Json
 
-#N2WS 2.5 return typo messeage!! [Cound not find policy] , thus do not match 'Could not find policy' orz
+#N2WS 2.5 return typo message!! [Cound not find policy] , thus do not match 'Could not find policy' orz
 
         IF (($id.Message -match 'not find policy') -or ($id."backup-id" -eq -1)) {
 


### PR DESCRIPTION
Hi, 

I discovered the 7zip behavior, and the -mmt switch has to be "on" hardcoded.

```
'^((7z|7zZip)(Archive|Compress)($|AndAddTimeStamp))$' {

            Push-Location -LiteralPath $7zFolder

            IF ($ActionType -match '7zZip') {
                
                $7zType = 'zip'
                
                } else {
                $7zType = '7z'
                }

            Switch -Regex ($ActionType){
            
                'Compress' {
                    [String]$errorDetail = .\7z.exe u -mmt=on $ActionTo $ActionFrom -t"$7zType"  2>&1
                    Break
                    }

                'Archive' {
                    [String]$errorDetail = .\7z.exe a -mmt=on $ActionTo $ActionFrom -t"$7zType"  2>&1 
                    Break
                    }
            
                Default {
                    Pop-Location 
                    Throw "Internal error in 7-Zip Switch section with Action Type"
                    }            
                }
```